### PR TITLE
Fix loading Encode::Alias

### DIFF
--- a/lib/Biber/Constants.pm
+++ b/lib/Biber/Constants.pm
@@ -3,6 +3,7 @@ use v5.24;
 use strict;
 use warnings;
 
+use Encode;
 use Encode::Alias;
 
 use parent qw(Exporter);


### PR DESCRIPTION
Loading Encode::Alias without loading Encode first fails with:

  Undefined subroutine &Encode::define_alias called at .../Encode.pm line 102

Tested with Encode 2.90, for which upstream documentation examples [1] also show
loading Encode first.

This problem was originally reported to MacPorts [2], where this patch is now already applied.

[1] http://search.cpan.org/~dankogai/Encode-2.90/lib/Encode/Alias.pm
[2] https://trac.macports.org/ticket/54351